### PR TITLE
Show likes post type in rest API

### DIFF
--- a/includes/post-type-like.php
+++ b/includes/post-type-like.php
@@ -46,6 +46,7 @@ function register(): void {
 			'public'               => true,
 			'menu_position'        => 6,
 			'menu_icon'            => 'dashicons-star-filled',
+			'show_in_rest'         => true,
 			'supports'             => false,
 			'register_meta_box_cb' => __NAMESPACE__ . '\register_meta_boxes',
 			'has_archive'          => true,


### PR DESCRIPTION
In order for FSE to create a likes archive page, the post type needs to be available through the rest API.